### PR TITLE
Фідбек

### DIFF
--- a/HW.rmd
+++ b/HW.rmd
@@ -27,8 +27,7 @@ colnames(air) <- colnames(air) %>%
 
 ```{r}
 air <- air %>%
-  mutate(date = as.Date(date)) %>%
-  group_by(week(date))
+  mutate(date = as.Date(date))
 
 air
   
@@ -66,7 +65,8 @@ air[,c("date","year","month", "day")]
 ```{r}
 air <- air %>%
  group_by(day,month) %>%
- filter(n() == 2)
+ filter(n() == 2) %>%    # Так, воно)
+ ungroup()    # забули розгрупувати, далі це може призвести до неочікуваної поведінки датафрейма
 
 air
   
@@ -86,7 +86,7 @@ wider_df
 ```{r}
 
 wider_df <- wider_df %>% 
-  mutate(flights = y2019/y2020,
+  mutate(flights = y2020/y2019,
        date = str_c("2020",month, day, sep="-"),
        date = ymd(date)
        )


### PR DESCRIPTION
99% правильно, результат той, що очікувався. З складними елементами — групування і з'єднання — все добре.
Була помилка в групуванні-фільтруванні: не розгрупували датафрейм. У цьому варіанті воно не призвело до інших помилок, але взагалі треба це робити, щоб потім не мати неочікуваних помилок на дальших етапах аналізу.
У підрахунку зміни польотів поділили 2019 на 2020. Вийшло, що у квітні 2019 було на 400% більше польотів, ціж у 2020. Як правило, люди порівнюють теперішнє з минулим. Тобто ми, логічніше, хотіли б знати, що в 2020-му кількість польотів склала лише 20% від рівня 2019-го року. По формі `mutate` правильний.